### PR TITLE
Fix Lollipop crash issue with android_actions

### DIFF
--- a/android/src/main/java/com/evollu/react/fcm/SendNotificationTask.java
+++ b/android/src/main/java/com/evollu/react/fcm/SendNotificationTask.java
@@ -256,7 +256,7 @@ public class SendNotificationTask extends AsyncTask<Void, Void, Void> {
                                     PendingIntent.FLAG_UPDATE_CURRENT);
                         }
 
-                        notification.addAction(1, actionTitle, pendingActionIntent);
+                        notification.addAction(0, actionTitle, pendingActionIntent);
                     }
                 }
 


### PR DESCRIPTION
App would crash when supplying any `android_actions` to the notification.

The resulting issue was due to the icon int value for the action which was set to 1 and failed to lookup drawable.